### PR TITLE
Fix Bug

### DIFF
--- a/Controller.php
+++ b/Controller.php
@@ -111,7 +111,7 @@ abstract class Controller {
 
 		foreach ($klass->getMethods() as $method) {
 			$comment = $method->getDocComment();
-			if (preg_match_all('#@(route|verb) (.*?)\r#', $comment, $pm)) {
+			if (preg_match_all('#@(route|verb) (.*?)\R#', $comment, $pm)) {
 				if (in_array('route', $pm[1])) {
 					$route = new Route($this, $method->name);
 					foreach ($pm[1] as $i => $m) {


### PR DESCRIPTION
The character \r by \R is corrected in the regular expression that looks for the path @route, it worked only in some configurations.